### PR TITLE
SASS/SCSS partials (files beginning with _) are now filtered

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
 
   :profiles {:dev {:dependencies [[speclj "2.5.0"]
                                   [org.rubygems/haml "3.1.7"]
-                                  [org.rubygems/sass "3.2.1"]]
+                                  [org.rubygems/sass "3.2.9"]]
                    :plugins [[speclj "2.5.0"]]
                    :test-paths ["spec/"]
                    :repositories [["gem-jars" "http://deux.gemjars.org"]]}
@@ -49,7 +49,7 @@
                                      ;; :auto-compile-delay 250
                                      ;; :delete-output-dir true ;; -> when running lein clean it will delete the output directory if it does not contain any file
                                      ;; :ignore-hooks [:clean :compile] ;; -> if you ue the hooks, allows you to remove some hooks that you don't want to run
-                                     :gem-version "3.2.1"
+                                     :gem-version "3.2.9"
                                      :style :nested ;; valid: :nested, :expanded, :compact, :compressed
                                      }}
                    }

--- a/src/leiningen/lein_common/file_utils.clj
+++ b/src/leiningen/lein_common/file_utils.clj
@@ -5,10 +5,10 @@
 (defn- ends-with-extension [file ext]
   (and (.isFile file) (.endsWith (.getName file) (str "." ext))))
 
-(defn- files-from [ext dir]
+(defn- files-from [dir file-filter]
   (let [f (io/file dir)
         fs (file-seq f)]
-    (filter #(ends-with-extension % ext) fs)))
+    (filter file-filter fs)))
 
 (defn- normalize-extension [ext]
   (if (or (nil? ext) (= \. (first ext)) (empty? ext))
@@ -25,10 +25,13 @@
       (str dest-dir rel-file))
     (.getPath file)))
 
-(defn dest-files-from [src-ext src-dir dest-dir dest-ext]
+(defn extension-filter [extension]
+  #(ends-with-extension % extension))
+
+(defn dest-files-from [src-filter src-ext src-dir dest-dir dest-ext]
   (map #(hash-map (keyword src-ext) (.getPath %)
                   :dest (replace-dest-dir (replace-extension % src-ext dest-ext) src-dir dest-dir))
-       (files-from src-ext src-dir)))
+       (files-from src-dir src-filter)))
 
 (defn exists [dir]
   (and dir (.exists (io/file dir))))

--- a/src/leiningen/lein_haml_sass/render_engine.clj
+++ b/src/leiningen/lein_haml_sass/render_engine.clj
@@ -51,8 +51,19 @@
          (ref-set rendering-engine (.runScriptlet @c "Sass::Engine"))
          (ref-set rendering-options (build-sass-options options)))))))
 
+(defn- sass-or-scss? [src-type]
+  (or (= :sass src-type) (= :scss src-type)))
+
+(defn- source-file-filter [src-type]
+  #(let [f %
+         extension-filter (extension-filter (name src-type))]
+     (and (extension-filter f)
+          (if (sass-or-scss? src-type)
+            (not (.startsWith (.getName f) "_"))
+            true))))
+
 (defn- files-from [{:keys [src src-type output-directory output-extension]}]
-  (dest-files-from (name src-type) src output-directory output-extension))
+  (dest-files-from (source-file-filter src-type) (name src-type) src output-directory output-extension))
 
 (defn render [src-type template]
   (try


### PR DESCRIPTION
Hello Renaud,

I thought this might be what you had in mind when you wrote "better support for sass partials" on the todo list? I use a lot of them and had found no obviuos way to prevent sass from trying to compile them a second time although they were already included in other files. I would be glad if this would make it into your master if the code is ok for you :-)

Kind regards,
Roland
